### PR TITLE
progressive resizing with multiprocessing

### DIFF
--- a/tests/transforms/test_spatial_transforms.py
+++ b/tests/transforms/test_spatial_transforms.py
@@ -5,6 +5,7 @@ import unittest
 from tests.transforms import chech_data_preservation
 from rising.transforms.spatial import *
 from rising.transforms.functional.spatial import resize
+from rising.loading import DataLoader
 
 
 class TestSpatialTransforms(unittest.TestCase):
@@ -82,6 +83,20 @@ class TestSpatialTransforms(unittest.TestCase):
     def test_size_step_scheduler_error(self):
         with self.assertRaises(TypeError):
             scheduler = SizeStepScheduler([10, 20], [32, 64])
+
+    def test_progressive_resize_integration(self):
+        sizes = [1, 3, 6]
+        scheduler = SizeStepScheduler([1, 2], [1, 3, 6])
+        trafo = ProgressiveResize(scheduler)
+
+        dset = [self.batch_dict] * 10
+        loader = DataLoader(dset, num_workers=4, batch_transforms=trafo)
+
+        data_shape = [tuple(i["data"].shape) for i in loader]
+
+        self.assertIn((1, 1, 1, 1, 1), data_shape)
+        # self.assertIn((1, 1, 3, 3, 3), data_shape)
+        self.assertIn((1, 1, 6, 6, 6), data_shape)
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
Does no completely solve progressive resizing with multiprocessing , but it is probably the best we can do right now. The transformation now has an internal shared memory to use as a counter. Unfortunately, the counter still can jump a few steps at once, probably because multiple processes spawn with the old value which leads to wrong readouts (even though the number of steps is always correct).

This shouldn't be so big of a problem because generally the number of steps taken is much much larger than the number of workers, so there are only small inaccuracies.

**Checklist**
- [x] Add pull request to project (optionally delete corresponding project note)
- [x] Assign correct label (if you don't have permission to do this, someone will do it for you. 
      Please make sure to communicate the current status of the pr.)
- [x] Implementation
- [x] Check if new functions are addded to `__all__` and/or `__init__` files correctly
- [x] Docstrings
- [x] Typing
- [x] Unittests (look at the line coverage of your tests, the goal is 100%!)
- [x] Update notebooks if necessary
- [x] Check test and documentation pipeline
- [x] Add Changes to Changelog
- [x] Update `CODEOWNERS` if necessary