### PR TITLE
updated PR template

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,13 +1,38 @@
-**Checklist**
-- [ ] Add pull request to project (optionally delete corresponding project note)
-- [ ] Assign correct label (if you don't have permission to do this, someone will do it for you. 
-      Please make sure to communicate the current status of the pr.)
+## Short Description
+Please give a short summary of the main points of this PR
+
+## PR Checklist
+### PR Implementer
+This is a small checklist for the implementation details of this PR.
+If you submit a PR, please look of these points (don't worry about the `RisingTeam`
+and `Reviewer` workflows, the only purpose of those is to have a compact view of
+the steps)
+
 - [ ] Implementation
-- [ ] Check if new functions are addded to `__all__` and/or `__init__` files correctly
-- [ ] Docstrings
-- [ ] Typing
+- [ ] Docstrings & Typing
+- [ ] Check `__all__` sections and `__init__`
 - [ ] Unittests (look at the line coverage of your tests, the goal is 100%!)
-- [ ] Update notebooks if necessary
-- [ ] Check test and documentation pipeline
-- [ ] Add Changes to Changelog
-- [ ] Update `CODEOWNERS` if necessary
+- [ ] Update notebooks & documentation if necessary
+- [ ] Pass all tests
+
+### RisingTeam
+<details>
+  <summary>RisingTeam workflow</summary>
+
+  - [ ] Add pull request to project (optionally delete corresponding project note)
+  - [ ] Assign correct label (if you don't have permission to do this, someone will do it for you. 
+      Please make sure to communicate the current status of the pr.)
+  - [ ] Does this PR close an Issue? (add `closes #IssueNumber` at the bottom if 
+        not already in description)
+</details>
+
+### Reviewer
+<details>
+  <summary>Reviewer workflow</summary>
+  
+  - [ ] Do all tests pass? (Unittests, NotebookTests, Documentation)
+  - [ ] Does the implementation follow `rising` design conventions?
+  - [ ] Are the tests useful? (!!!) Are additional tests needed? 
+        Can you think of critical points which should be covered in an additional test?
+  - [ ] Optional: Check coverage locally / Check tests locally if GPU is necessary to execute
+</details>

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -4,9 +4,12 @@ Please give a short summary of the main points of this PR
 ## PR Checklist
 ### PR Implementer
 This is a small checklist for the implementation details of this PR.
-If you submit a PR, please look of these points (don't worry about the `RisingTeam`
+If you submit a PR, please look at these points (don't worry about the `RisingTeam`
 and `Reviewer` workflows, the only purpose of those is to have a compact view of
 the steps)
+
+If there are any questions regarding code style or other conventions check out our 
+[summary](https://github.com/PhoenixDL/rising/blob/master/CONTRIBUTING.md).
 
 - [ ] Implementation
 - [ ] Docstrings & Typing

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -87,6 +87,15 @@ from the `rising` root directory or run individual test files, like `python test
 ### Better local unit tests with unittest
 Testing is done with a `unittest` suite
 
+You can run your tests with coverage by installing ´coverage´ and executing
+
+```bash
+coverage run -m unittest; coverage report -m;
+```
+
+inside the terminal. Pycharm Professional supports `Run with coverage` directly. 
+Furthermore, the coverage is always computed and uploaded when you execute `git push` and can be seen on github.
+
 ## Writing documentation
 
 `rising` uses [numpy style](http://sphinxcontrib-napoleon.readthedocs.io/en/latest/example_numpy.html)


### PR DESCRIPTION
The new template should be more readable und useful than the current version :) 
I moved `update Codeowners` and `update Changelog` to the `Tag release` note in the `orga` project

**Checklist**
- [x] Add pull request to project (optionally delete corresponding project note)
- [x] Assign correct label (if you don't have permission to do this, someone will do it for you. 
      Please make sure to communicate the current status of the pr.)
- [x] Implementation
- [x] Check if new functions are addded to `__all__` and/or `__init__` files correctly
- [x] Docstrings
- [x] Typing
- [x] Unittests (look at the line coverage of your tests, the goal is 100%!)
- [x] Update notebooks if necessary
- [x] Check test and documentation pipeline

Closes https://github.com/PhoenixDL/rising/issues/18