### PR TITLE
add warning filters

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 | Date | Commit | Short Description | Breaking Changes? |
 | ---- | --------- | ----------------- | ----------------- |
+| 2020-05-15 | 29457c9ba8435369bb1db259cb7488698cde755b | Filter warnings after first occurence | No |
 | 2020-04-30 | cc622d423cf58136cde86860e746e119f3f0a7fb | Remove non-necessary stuff | Yes |
 | 2020-04-30 | b39d2abd190fcb76b3ed908a65e42f9492c7dcd6 | Add notebook tests for windows and mac | No |
 | 2020-04-30 | 89a10c72d927b72241ed9138099f4f2a0e015a3f | Add tests for windows and mac | No |

--- a/rising/__init__.py
+++ b/rising/__init__.py
@@ -26,4 +26,8 @@ if __RISING_SETUP__:
     sys.stdout.write(f'Partial import of `{__name__}` during the build process.\n')  # pragma: no-cover
     # We are not importing the rest of the lightning during the build process, as it may not be compiled yet
 else:
+    import sys
+    if not sys.warnoptions:
+        import warnings
+        warnings.simplefilter("once")
     from rising.interface import AbstractMixin


### PR DESCRIPTION
## Short Description
Reduces the amount of warnings. Each warning will only be displayed once. Otherwise you get num epochs * num_loaders * num_worker times the same warning.

## PR Checklist
### PR Implementer
This is a small checklist for the implementation details of this PR.
If you submit a PR, please look at these points (don't worry about the `RisingTeam`
and `Reviewer` workflows, the only purpose of those is to have a compact view of
the steps)

If there are any questions regarding code style or other conventions check out our 
[summary](https://github.com/PhoenixDL/rising/blob/master/CONTRIBUTING.md).

- [ ] Implementation
- [ ] Docstrings & Typing
- [ ] Check `__all__` sections and `__init__`
- [ ] Unittests (look at the line coverage of your tests, the goal is 100%!)
- [ ] Update notebooks & documentation if necessary
- [ ] Pass all tests
- [ ] Add the checksum of the last implementation commit to the Changelog

### RisingTeam
<details>
  <summary>RisingTeam workflow</summary>

  - [ ] Add pull request to project (optionally delete corresponding project note)
  - [ ] Assign correct label (if you don't have permission to do this, someone will do it for you. 
      Please make sure to communicate the current status of the pr.)
  - [ ] Does this PR close an Issue? (add `closes #IssueNumber` at the bottom if 
        not already in description)
</details>

### Reviewer
<details>
  <summary>Reviewer workflow</summary>
  
  - [ ] Do all tests pass? (Unittests, NotebookTests, Documentation)
  - [ ] Does the implementation follow `rising` design conventions?
  - [ ] Are the tests useful? (!!!) Are additional tests needed? 
        Can you think of critical points which should be covered in an additional test?
  - [ ] Optional: Check coverage locally / Check tests locally if GPU is necessary to execute
</details>
