### PR TITLE
Add kwargs to loader

### DIFF
--- a/rising/loading/loader.py
+++ b/rising/loading/loader.py
@@ -99,7 +99,9 @@ class DataLoader(_DataLoader):
                  worker_init_fn: Optional[Callable] = None,
                  multiprocessing_context=None,
                  auto_convert: bool = True,
-                 transform_call: Callable[[Any, Callable], Any] = default_transform_call):
+                 transform_call: Callable[[Any, Callable], Any] = default_transform_call,
+                 **kwargs
+                ):
         """
         Args:
             dataset: dataset from which to load the data
@@ -163,7 +165,7 @@ class DataLoader(_DataLoader):
                          collate_fn=collate_fn, pin_memory=pin_memory,
                          drop_last=drop_last, timeout=timeout,
                          worker_init_fn=worker_init_fn,
-                         multiprocessing_context=multiprocessing_context)
+                         multiprocessing_context=multiprocessing_context, **kwargs)
 
         if gpu_transforms is not None and not torch.cuda.is_available():
             if hasattr(gpu_transforms, 'to'):

--- a/rising/loading/loader.py
+++ b/rising/loading/loader.py
@@ -101,7 +101,7 @@ class DataLoader(_DataLoader):
                  auto_convert: bool = True,
                  transform_call: Callable[[Any, Callable], Any] = default_transform_call,
                  **kwargs
-                ):
+                 ):
         """
         Args:
             dataset: dataset from which to load the data


### PR DESCRIPTION
## Short Description
Adds keyword arguments to support additional arguments like the new, but yet undocumented [generator arg](https://github.com/pytorch/pytorch/blob/master/torch/utils/data/dataloader.py#L153)  and also being backwards compatible.

## PR Checklist
### PR Implementer
This is a small checklist for the implementation details of this PR.
If you submit a PR, please look at these points (don't worry about the `RisingTeam`
and `Reviewer` workflows, the only purpose of those is to have a compact view of
the steps)

If there are any questions regarding code style or other conventions check out our 
[summary](https://github.com/PhoenixDL/rising/blob/master/CONTRIBUTING.md).

- [x] Implementation
- [x] Docstrings & Typing
- [x] Check `__all__` sections and `__init__`
- [x] Unittests (look at the line coverage of your tests, the goal is 100%!)
- [x] Update notebooks & documentation if necessary
- [ ] Pass all tests
- [ ] Add the checksum of the last implementation commit to the Changelog

### RisingTeam
<details>
  <summary>RisingTeam workflow</summary>

  - [ ] Add pull request to project (optionally delete corresponding project note)
  - [ ] Assign correct label (if you don't have permission to do this, someone will do it for you. 
      Please make sure to communicate the current status of the pr.)
  - [ ] Does this PR close an Issue? (add `closes #IssueNumber` at the bottom if 
        not already in description)
</details>

### Reviewer
<details>
  <summary>Reviewer workflow</summary>
  
  - [ ] Do all tests pass? (Unittests, NotebookTests, Documentation)
  - [ ] Does the implementation follow `rising` design conventions?
  - [ ] Are the tests useful? (!!!) Are additional tests needed? 
        Can you think of critical points which should be covered in an additional test?
  - [ ] Optional: Check coverage locally / Check tests locally if GPU is necessary to execute
</details>
