### PR TITLE
Adds correct image transformation

### DIFF
--- a/rising/utils/inverse.py
+++ b/rising/utils/inverse.py
@@ -1,0 +1,13 @@
+import torch
+
+
+def orthogonal_inverse(mat: torch.Tensor) -> torch.Tensor:
+    """
+    Creates the inverse matrix of an orthogonal matrix
+    Its basically just the transposed matrix :D
+    Args:
+        mat: Orthogonal matrix
+    Return:
+        Inverse of the input matrix
+    """
+    return torch.transpose(mat, -1, -2)

--- a/tests/transforms/functional/test_affine.py
+++ b/tests/transforms/functional/test_affine.py
@@ -218,15 +218,23 @@ class AffineTestCase(unittest.TestCase):
     def test_matrix_parametrization(self):
         inputs = [
             {'scale': None, 'translation': None, 'rotation': None, 'batchsize': 2, 'ndim': 2,
-             'dtype': torch.float},
+             'dtype': torch.float, "image_transform": False},
+            {'scale': [4, 5], 'translation': [2, 3], 'rotation': 90, 'batchsize': 1, 'ndim': 2,
+             'dtype': torch.float, "degree": True, "image_transform": False},
+            {'scale': [4, 5], 'translation': [2, 3], 'rotation': 90, 'batchsize': 1, 'ndim': 2,
+             'dtype': torch.float, "degree": True, "image_transform": True},
             {'scale': [2, 5], 'translation': [9, 18, 27],
              'rotation': [180, 0, 180], 'degree': True, 'batchsize': 3,
-             'ndim': 2, 'dtype':torch.float}
+             'ndim': 2, 'dtype':torch.float, "image_transform": False}
         ]
 
         expectations = [
             torch.tensor([[[1., 0., 0.], [0., 1., 0.], [0., 0., 1.]],
                           [[1., 0., 0.], [0., 1., 0.], [0., 0., 1.]]]),
+
+            torch.tensor([[[0., -4., -12.], [5., 0., 10.], [0., 0., 1.]]]),
+
+            torch.tensor([[[0., 1/5., -2.], [-1/4., 0., -3.], [0., 0., 1.]]]),
 
             torch.bmm(torch.bmm(torch.tensor([[[2., 0., 0], [0., 5., 0.], [0., 0., 1.]],
                                               [[2., 0., 0.], [0., 5., 0.], [0., 0., 1.]],
@@ -241,7 +249,7 @@ class AffineTestCase(unittest.TestCase):
 
         for inp, exp in zip(inputs, expectations):
             with self.subTest(input=inp, expected=exp):
-                res = parametrize_matrix(**inp, image_transform=False).to(exp.dtype)
+                res = parametrize_matrix(**inp).to(exp.dtype)
                 self.assertTrue(torch.allclose(res, matrix_to_cartesian(exp), atol=1e-6))
 
 


### PR DESCRIPTION
## Short Description
Added the parameter image_transform to create_rotation and added the reversed multiplication of sub transformations in parametrize_matrix to calculate the correct inverse for image transformations.
Fixes #109 

## PR Checklist
### PR Implementer
This is a small checklist for the implementation details of this PR.
If you submit a PR, please look at these points (don't worry about the `RisingTeam`
and `Reviewer` workflows, the only purpose of those is to have a compact view of
the steps)

If there are any questions regarding code style or other conventions check out our 
[summary](https://github.com/PhoenixDL/rising/blob/master/CONTRIBUTING.md).

- [x] Implementation
- [x] Docstrings & Typing
- [ ] Check `__all__` sections and `__init__`
- [x] Unittests (look at the line coverage of your tests, the goal is 100%!)
- [x] Update notebooks & documentation if necessary
- [x] Pass all tests
- [ ] Add the checksum of the last implementation commit to the Changelog

### RisingTeam
<details>
  <summary>RisingTeam workflow</summary>

  - [ ] Add pull request to project (optionally delete corresponding project note)
  - [ ] Assign correct label (if you don't have permission to do this, someone will do it for you. 
      Please make sure to communicate the current status of the pr.)
  - [ ] Does this PR close an Issue? (add `closes #IssueNumber` at the bottom if 
        not already in description)
</details>

### Reviewer
<details>
  <summary>Reviewer workflow</summary>
  
  - [ ] Do all tests pass? (Unittests, NotebookTests, Documentation)
  - [ ] Does the implementation follow `rising` design conventions?
  - [ ] Are the tests useful? (!!!) Are additional tests needed? 
        Can you think of critical points which should be covered in an additional test?
  - [ ] Optional: Check coverage locally / Check tests locally if GPU is necessary to execute
</details>
